### PR TITLE
Two minor bugs in gamma table generation

### DIFF
--- a/pdm_fade_gamma/gen_gamma_table.c
+++ b/pdm_fade_gamma/gen_gamma_table.c
@@ -1,5 +1,5 @@
 /*
- *  icebreaker examples - gamma pwm demo 
+ *  icebreaker examples - gamma pwm demo
  *
  *  Copyright (C) 2018 Piotr Esden-Tempski <piotr@esden.net>
  *
@@ -30,7 +30,7 @@ int main()
 	fprintf(stderr, "Generating the gamma lookup table.\n");
 
 	for (int i = 0; i < 256; i++) {
-		double dvalue = pow((1.0 / 256.0) * i, GAMMA);
+		double dvalue = pow((1.0 / 255.0) * i, GAMMA);
 		long lvalue = 0xFFFFl * dvalue;
 
 		fprintf(stderr, ".");

--- a/pdm_fade_gamma/gen_gamma_table.c
+++ b/pdm_fade_gamma/gen_gamma_table.c
@@ -36,11 +36,14 @@ int main()
 		fprintf(stderr, ".");
 
 		if ((i % 8) == 0) {
-			printf("%s@%08x ", (i != 0) ? "\n" : "", i);
+			printf("@%08x", i);
 		}
-		printf("%04lX ", lvalue);
+		printf(" %04lX", lvalue);
 		//printf("%f\n", value);
 		//printf("%5i | %f\n", i, value);
+		if ((i % 8) == 7) {
+			printf("\n");
+		}
 	}
 
 	fprintf(stderr, "\ndone\n");

--- a/pwm_fade_gamma/gen_gamma_table.c
+++ b/pwm_fade_gamma/gen_gamma_table.c
@@ -1,5 +1,5 @@
 /*
- *  icebreaker examples - gamma pwm demo 
+ *  icebreaker examples - gamma pwm demo
  *
  *  Copyright (C) 2018 Piotr Esden-Tempski <piotr@esden.net>
  *
@@ -30,7 +30,7 @@ int main()
 	fprintf(stderr, "Generating the gamma lookup table.\n");
 
 	for (int i = 0; i < 256; i++) {
-		double dvalue = pow((1.0 / 256.0) * i, GAMMA);
+		double dvalue = pow((1.0 / 255.0) * i, GAMMA);
 		long lvalue = 0xFFFFl * dvalue;
 
 		fprintf(stderr, ".");

--- a/pwm_fade_gamma/gen_gamma_table.c
+++ b/pwm_fade_gamma/gen_gamma_table.c
@@ -36,11 +36,14 @@ int main()
 		fprintf(stderr, ".");
 
 		if ((i % 8) == 0) {
-			printf("%s@%08x ", (i != 0) ? "\n" : "", i);
+			printf("@%08x", i);
 		}
-		printf("%04lX ", lvalue);
+		printf(" %04lX", lvalue);
 		//printf("%f\n", value);
 		//printf("%5i | %f\n", i, value);
+		if ((i % 8) == 7) {
+			printf("\n");
+		}
 	}
 
 	fprintf(stderr, "\ndone\n");


### PR DESCRIPTION
The gamma table was not achieving full brightness.  The highest gamma input, 0xFF, was mapped to 0xFDCD.  Now it's mapped to 0xFFFF.

Also, the whitespace was not quite right.  Extra trailing blank on every line, missing newline on last line.
(Only matters to someone who lives in their terminal.)