### PR TITLE
Gitter->Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ For installation instructions of the icestorm flow follow the instructons on the
 
 The default Placement Constraint File (.pcf) for iCEBreaker can be found in the toplevel directory and contains references to all the default pins on the iCEBreaker development board. This file can be referenced by all the examples that use that board.
 
-If you have any questions please join the gitter channel and ask away: http://gitter.im/icebreaker-fpga/Lobby
+If you have any questions please join the Discord channel and ask away: [1bitsquared.com/pages/chat](https://1bitsquared.com/pages/chat/)


### PR DESCRIPTION
Since the Gitter channel is discontinued it's probably good to link to the Discord channel that is replacing it.